### PR TITLE
Fix data loading from API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       noteItem.setAttribute('title', note.title);
       noteItem.setAttribute('body', note.body);
       noteItem.setAttribute('date', new Date(note.createdAt).toLocaleDateString());
+      noteItem.setAttribute('id', note.id);
       noteList.appendChild(noteItem);
     });
   };

--- a/src/script/component/note-item.js
+++ b/src/script/component/note-item.js
@@ -1,3 +1,5 @@
+import { deleteNote } from '../data/api.js';
+
 class NoteItem extends HTMLElement {
   connectedCallback() {
     this.title = this.getAttribute('title');

--- a/src/script/component/note-list.js
+++ b/src/script/component/note-list.js
@@ -13,6 +13,7 @@ class NoteList extends HTMLElement {
       noteItem.setAttribute('title', note.title);
       noteItem.setAttribute('body', note.body);
       noteItem.setAttribute('date', new Date(note.createdAt).toLocaleDateString());
+      noteItem.setAttribute('id', note.id);
       this.appendChild(noteItem);
     });
   }


### PR DESCRIPTION
Add `id` attribute to note items in `src/index.js` and `src/script/component/note-list.js`.

* **`src/index.js`**
  - Add `id` attribute to note items in `renderNotes` function.

* **`src/script/component/note-item.js`**
  - Import `deleteNote` from `../data/api.js`.

* **`src/script/component/note-list.js`**
  - Add `id` attribute to note items in `renderNotes` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alfaniM/notes-app-learn-webpack-2025-update/pull/2?shareId=04dbc3f1-4696-4800-9ef9-63fe435a0e9d).